### PR TITLE
libusb_example: Fix undefined reference error caused by old libusb versi...

### DIFF
--- a/libusb_example/flexiband_record.c
+++ b/libusb_example/flexiband_record.c
@@ -10,6 +10,8 @@
 #include <sys/stat.h>
 #include <libusb-1.0/libusb.h>
 
+#include "libusb_version_fixes.h"
+
 #define INTERFACE     0
 #define ALT_INTERFACE 1
 

--- a/libusb_example/libusb_version_fixes.h
+++ b/libusb_example/libusb_version_fixes.h
@@ -1,0 +1,37 @@
+#include <libusb-1.0/libusb.h>
+
+#if (LIBUSB_NANO < 10733)
+const char *libusb_strerror(enum libusb_error error) {
+    switch (error) {
+        case LIBUSB_SUCCESS:
+            return "LIBUSB_SUCCESS";
+        case LIBUSB_ERROR_IO:
+            return "LIBUSB_ERROR_IO";
+        case LIBUSB_ERROR_INVALID_PARAM:
+            return "LIBUSB_ERROR_INVALID_PARAM";
+        case LIBUSB_ERROR_ACCESS:
+            return "LIBUSB_ERROR_ACCESS";
+        case LIBUSB_ERROR_NO_DEVICE:
+            return "LIBUSB_ERROR_NO_DEVICE";
+        case LIBUSB_ERROR_NOT_FOUND:
+            return "LIBUSB_ERROR_NOT_FOUND";
+        case LIBUSB_ERROR_BUSY:
+            return "LIBUSB_ERROR_BUSY";
+        case LIBUSB_ERROR_TIMEOUT:
+            return "LIBUSB_ERROR_TIMEOUT";
+        case LIBUSB_ERROR_OVERFLOW:
+            return "LIBUSB_ERROR_OVERFLOW";
+        case LIBUSB_ERROR_PIPE:
+            return "LIBUSB_ERROR_PIPE";
+        case LIBUSB_ERROR_INTERRUPTED:
+            return "LIBUSB_ERROR_INTERRUPTED";
+        case LIBUSB_ERROR_NO_MEM:
+            return "LIBUSB_ERROR_NO_MEM";
+        case LIBUSB_ERROR_NOT_SUPPORTED:
+            return "LIBUSB_ERROR_NO_SUPPOERTED";
+        case LIBUSB_ERROR_OTHER:
+        default:
+            return "LIBUSB_ERROR_OTHER";
+    }
+}
+#endif

--- a/libusb_example/upload_fpga.c
+++ b/libusb_example/upload_fpga.c
@@ -6,6 +6,8 @@
 #include <unistd.h>
 #include <libusb-1.0/libusb.h>
 
+#include "libusb_version_fixes.h"
+
 #define INTERFACE     0
 #define VID      0x27ae
 #define PID      0x1016


### PR DESCRIPTION
...ons

The function libusb_strerror was introduced with nano version 10733.
It is implemented if the version is smaller.
