### PR TITLE
driver:linux:src: Fix memory leak of 208 byte per execution.

### DIFF
--- a/driver/linux/src/flexiband_fpga.c
+++ b/driver/linux/src/flexiband_fpga.c
@@ -251,6 +251,7 @@ static int upload_fpga(libusb_device_handle *dev_handle, const char *filename, b
             printf("Error handle event");
         }
 
+        libusb_free_transfer(xfr);
         usleep(100000); // TODO Check, if FPGA is ready
         printf("Done\n");
     }


### PR DESCRIPTION
Verifiable via valgrind. Be aware of flase positive additional to leak.